### PR TITLE
Update pre-commit-lite conditions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,7 +28,7 @@ jobs:
         id: pre_commit
       # run pre-commit ci lite for automated fixes
       - uses: pre-commit-ci/lite-action@v1.1.0
-        if: ${{ !cancelled() if: ${{ !cancelled() }}if: ${{ !cancelled() }} steps.pre_commit.outcome == 'failure' }}
+        if: ${{ !cancelled() && steps.pre_commit.outcome == 'failure' }}
   run_tests:
     strategy:
       matrix:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,9 +25,10 @@ jobs:
         run: poetry install --no-interaction --no-ansi
       # run pre-commit
       - uses: pre-commit/action@v3.0.1
+        id: pre_commit
       # run pre-commit ci lite for automated fixes
       - uses: pre-commit-ci/lite-action@v1.1.0
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() if: ${{ !cancelled() }}if: ${{ !cancelled() }} steps.pre_commit.outcome == 'failure' }}
   run_tests:
     strategy:
       matrix:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     -   id: check-added-large-files
     -   id: detect-private-key
 -   repo: https://github.com/python-poetry/poetry
-    rev: "2.1.2"
+    rev: "2.1.3"
     hooks:
     -   id: poetry-check
 -   repo: https://github.com/tox-dev/pyproject-fmt
@@ -45,7 +45,7 @@ repos:
     hooks:
     -   id: validate-cff
 -   repo: https://github.com/adrienverge/yamllint
-    rev: v1.37.0
+    rev: v1.37.1
     hooks:
     -   id: yamllint
         exclude: pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
     hooks:
     -   id: actionlint
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.11.7"
+    rev: "v0.11.9"
     hooks:
     -   id: ruff-format
     -   id: ruff


### PR DESCRIPTION
This PR updates the pre-commit-lite conditions so that only failures of pre-commit can trigger updates from pre-commit-lite. Without this change, updates may occur without pre-commit failures.